### PR TITLE
feat: support `@computed_field` of pydantic v2

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -266,6 +266,61 @@ class ExpressionField(str):
         return self
 
 
+class ExpressionFieldProperty(property):
+    def __init__(
+        self, original_property: property, expression_field: ExpressionField
+    ):
+        self._original = original_property
+        self._expression_field = expression_field
+        super().__init__(
+            original_property.fget,
+            original_property.fset,
+            original_property.fdel,
+            original_property.__doc__,
+        )
+
+    def __getitem__(self, item):
+        return ExpressionField(f"{self._expression_field}.{item}")
+
+    def __getattr__(self, item):
+        return ExpressionField(f"{self._expression_field}.{item}")
+
+    def __hash__(self):
+        return hash(str(self._expression_field))
+
+    def __eq__(self, other):
+        if isinstance(other, ExpressionField):
+            return super(ExpressionField, self._expression_field).__eq__(other)
+        return Eq(field=self, other=other)
+
+    def __gt__(self, other):
+        return GT(field=self._expression_field, other=other)
+
+    def __ge__(self, other):
+        return GTE(field=self._expression_field, other=other)
+
+    def __lt__(self, other):
+        return LT(field=self._expression_field, other=other)
+
+    def __le__(self, other):
+        return LTE(field=self._expression_field, other=other)
+
+    def __ne__(self, other):
+        return NE(field=self._expression_field, other=other)
+
+    def __pos__(self):
+        return self._expression_field, SortDirection.ASCENDING
+
+    def __neg__(self):
+        return self._expression_field, SortDirection.DESCENDING
+
+    def __copy__(self):
+        return self._expression_field
+
+    def __deepcopy__(self, memo):
+        return self._expression_field
+
+
 class DeleteRules(str, Enum):
     DO_NOTHING = "DO_NOTHING"
     DELETE_LINKS = "DELETE_LINKS"

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -27,6 +27,7 @@ from beanie.odm.fields import Link, LinkTypes
 from beanie.odm.utils.pydantic import (
     IS_PYDANTIC_V2,
     IS_PYDANTIC_V2_10,
+    get_model_all_items,
     get_model_fields,
 )
 
@@ -157,7 +158,7 @@ class Encoder:
     ) -> Iterable[Tuple[str, Any]]:
         keep_nulls = self.keep_nulls
         get_model_field = get_model_fields(obj).get
-        for key, value in obj.__iter__():
+        for key, value in get_model_all_items(obj).items():
             field_info = get_model_field(key)
             if field_info is not None:
                 key = field_info.alias or key
@@ -167,7 +168,9 @@ class Encoder:
                 yield key, value
 
     def _should_exclude_field(
-        self, key: str, field_info: Optional[pydantic.fields.FieldInfo]
+        self,
+        key: str,
+        field_info: Any,
     ):
         exclude, include = (
             self.exclude,
@@ -180,7 +183,7 @@ class Encoder:
         is_pydantic_excluded_field = (
             field_info is not None
             and (
-                field_info.exclude
+                getattr(field_info, "exclude", None)
                 if IS_PYDANTIC_V2
                 else getattr(field_info.field_info, "exclude")
             )

--- a/beanie/odm/utils/init.py
+++ b/beanie/odm/utils/init.py
@@ -6,6 +6,7 @@ from typing_extensions import Sequence, get_args, get_origin
 from beanie.odm.utils.pydantic import (
     IS_PYDANTIC_V2,
     get_extra_field_info,
+    get_field_type,
     get_model_fields,
     parse_model,
 )
@@ -38,6 +39,7 @@ from beanie.odm.documents import DocType, Document
 from beanie.odm.fields import (
     BackLink,
     ExpressionField,
+    ExpressionFieldProperty,
     Link,
     LinkInfo,
     LinkTypes,
@@ -221,9 +223,9 @@ class Initializer:
         :param field: ModelField
         :return: Optional[LinkInfo]
         """
-
-        origin = get_origin(field.annotation)
-        args = get_args(field.annotation)
+        annotation = get_field_type(field)
+        origin = get_origin(annotation)
+        args = get_args(annotation)
         classes = [
             Link,
             BackLink,
@@ -232,8 +234,8 @@ class Initializer:
         for cls in classes:
             # Check if annotation is one of the custom classes
             if (
-                isinstance(field.annotation, _GenericAlias)
-                and field.annotation.__origin__ is cls
+                isinstance(annotation, _GenericAlias)
+                and annotation.__origin__ is cls
             ):
                 if cls is Link:
                     return LinkInfo(
@@ -404,7 +406,14 @@ class Initializer:
             cls._link_fields = {}
         for k, v in get_model_fields(cls).items():
             path = v.alias or k
-            setattr(cls, k, ExpressionField(path))
+            attr = getattr(cls, k, None)
+            expression_field = ExpressionField(path)
+            if isinstance(attr, property):
+                setattr(
+                    cls, k, ExpressionFieldProperty(attr, expression_field)
+                )
+            else:
+                setattr(cls, k, expression_field)
 
             link_info = self.detect_link(v, k)
             depth_level = cls.get_settings().max_nesting_depths_per_field.get(

--- a/beanie/odm/utils/pydantic.py
+++ b/beanie/odm/utils/pydantic.py
@@ -10,6 +10,7 @@ IS_PYDANTIC_V2_10 = (
 
 if IS_PYDANTIC_V2:
     from pydantic import TypeAdapter
+    from pydantic.fields import ComputedFieldInfo
 else:
     from pydantic import parse_obj_as
 
@@ -23,16 +24,34 @@ def parse_object_as(object_type: Type, data: Any):
 
 def get_field_type(field):
     if IS_PYDANTIC_V2:
-        return field.annotation
+        if isinstance(field, ComputedFieldInfo):
+            return field.return_type
+        else:
+            return field.annotation
     else:
         return field.outer_type_
 
 
 def get_model_fields(model):
     if IS_PYDANTIC_V2:
-        return model.model_fields
+        return {**model.model_fields, **model.model_computed_fields}
     else:
         return model.__fields__
+
+
+def get_model_all_items(model):
+    if IS_PYDANTIC_V2:
+        return {
+            **dict(model.__iter__()),
+            **{
+                key: getattr(model, key)
+                for key in {
+                    **model.model_computed_fields,
+                }.keys()
+            },
+        }
+    else:
+        return dict(model.__iter__())
 
 
 def parse_model(model_type: Type[BaseModel], data: Any):

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -40,6 +40,7 @@ from tests.odm.models import (
     DocumentWithBsonBinaryField,
     DocumentWithBsonEncodersFiledsTypes,
     DocumentWithComplexDictKey,
+    DocumentWithComputedField,
     DocumentWithCustomFiledsTypes,
     DocumentWithCustomIdInt,
     DocumentWithCustomIdUUID,
@@ -209,6 +210,7 @@ TESTING_MODELS = [
     BsonRegexDoc,
     NativeRegexDoc,
     DocumentWithExcludedField,
+    DocumentWithComputedField,
 ]
 
 

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -61,7 +61,7 @@ from beanie.odm.union_doc import UnionDoc
 from beanie.odm.utils.pydantic import IS_PYDANTIC_V2
 
 if IS_PYDANTIC_V2:
-    from pydantic import RootModel, validate_call
+    from pydantic import RootModel, computed_field, validate_call
 
 if sys.version_info >= (3, 10):
 
@@ -899,6 +899,30 @@ class DocumentWithKeepNullsFalse(Document):
 class DocumentWithExcludedField(Document):
     included_field: int
     excluded_field: Optional[int] = Field(default=None, exclude=True)
+
+
+class DocumentWithComputedField(Document):
+    num: int
+
+    _cached_uuid: Optional[str] = None
+
+    if IS_PYDANTIC_V2:
+
+        @computed_field
+        @property
+        def doubled(self) -> int:
+            return self.num * 2
+
+        @computed_field
+        @property
+        def cacheable_uuid(self) -> str:
+            if self._cached_uuid is None:
+                self._cached_uuid = str(uuid4())
+            return self._cached_uuid
+
+        @cacheable_uuid.setter
+        def cacheable_uuid(self, new: str) -> None:
+            self._cached_uuid = new
 
 
 class ReleaseElemMatch(BaseModel):

--- a/tests/odm/test_encoder.py
+++ b/tests/odm/test_encoder.py
@@ -16,6 +16,7 @@ from tests.odm.models import (
     DocumentForEncodingTest,
     DocumentForEncodingTestDate,
     DocumentWithComplexDictKey,
+    DocumentWithComputedField,
     DocumentWithDecimalField,
     DocumentWithEnumKeysDict,
     DocumentWithExcludedField,
@@ -144,6 +145,15 @@ async def test_excluded():
     encoded_doc = Encoder().encode(doc)
     assert "included_field" in encoded_doc
     assert "excluded_field" not in encoded_doc
+
+
+@pytest.mark.skipif(not IS_PYDANTIC_V2, reason="Test only for Pydantic v2")
+def test_computed_field():
+    doc = DocumentWithComputedField(num=1)
+    encoded_doc = Encoder().encode(doc)
+    print(doc)
+    print(encoded_doc)
+    assert encoded_doc["doubled"] == 2
 
 
 @pytest.mark.skipif(not IS_PYDANTIC_V2, reason="Test only for Pydantic v2")

--- a/tests/odm/test_fields.py
+++ b/tests/odm/test_fields.py
@@ -17,6 +17,7 @@ from tests.odm.models import (
     DocumentTestModel,
     DocumentTestModelIndexFlagsAnnotated,
     DocumentWithBsonEncodersFiledsTypes,
+    DocumentWithComputedField,
     DocumentWithCustomFiledsTypes,
     DocumentWithDeprecatedHiddenField,
     DocumentWithExcludedField,
@@ -122,6 +123,44 @@ async def test_excluded(document):
     else:
         assert "included_field" in stored_doc.dict()
         assert "excluded_field" not in stored_doc.dict()
+
+
+@pytest.mark.skipif(not IS_PYDANTIC_V2, reason="Test only for Pydantic v2")
+async def test_computed_field():
+    doc = DocumentWithComputedField(num=1)
+    assert doc.doubled == 2
+
+    await doc.insert()
+    stored_doc = await DocumentWithComputedField.get(doc.id)
+    assert stored_doc and stored_doc.doubled == 2
+
+    stored_doc.num = 2
+    assert stored_doc.doubled == 4
+
+    await stored_doc.replace()
+    replaced_doc = await DocumentWithComputedField.get(doc.id)
+    assert replaced_doc and replaced_doc.doubled == 4
+
+
+@pytest.mark.skipif(not IS_PYDANTIC_V2, reason="Test only for Pydantic v2")
+async def test_computed_field_setter():
+    doc = DocumentWithComputedField(num=1)
+    await doc.insert()
+    cached_uui = doc.cacheable_uuid
+    db_raw_data = (
+        await DocumentWithComputedField.get_motor_collection().find_one(
+            {"_id": doc.id}
+        )
+    )
+    assert db_raw_data == {
+        "_id": doc.id,
+        "num": 1,
+        "doubled": 2,
+        "cacheable_uuid": cached_uui,
+    }
+
+    fetched_doc = await DocumentWithComputedField.get(doc.id)
+    assert fetched_doc and fetched_doc.cacheable_uuid != cached_uui
 
 
 async def test_hidden(deprecated_init_beanie):


### PR DESCRIPTION
This PR adds support for `@computed_field` to Beanie, which is currently not supported.

reference:
- [model_fields](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_fields)
- [model_computed_fields](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_computed_fields)
